### PR TITLE
running instance of mongodb required in dev branch

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -8,10 +8,10 @@ debug_templates = true
 default_locale_name = en
 results_path = %(here)s/results
 
-mongo.url = mongodb://localhost/
-mongo.dbpath = %(here)s/data
-mongo.dbname = WebOOT
-mongo.run = True
+#mongo.url = mongodb://localhost/
+#mongo.dbpath = %(here)s/data
+#mongo.dbname = WebOOT
+#mongo.run = True
 
 [app:velruse]
 use = egg:velruse


### PR DESCRIPTION
Hi!

Using the dev branch I get the following error if I don't run mongodb when I access a histogram:

URL: http://127.0.0.1:6543/browse/ZeeDAnalysis.root/%2A/%21compose/stack/NoShift/NoCuts/Boson/BosMass2/
File '/home/sschmitt/programme/WebOOT/env/lib/python2.6/site-packages/weberror/evalexception.py', line 431 in respond
  app_iter = self.application(environ, detect_start_response)
File '/home/sschmitt/programme/WebOOT/env/lib/python2.6/site-packages/pyramid/router.py', line 187 in **call**
  response = self.handle_request(request)
File '/home/sschmitt/programme/WebOOT/env/lib/python2.6/site-packages/pyramid/tweens.py', line 20 in excview_tween
  response = handler(request)
File '/home/sschmitt/programme/WebOOT/env/lib/python2.6/site-packages/pyramid/router.py', line 164 in handle_request
  response = view_callable(context, request)
File '/home/sschmitt/programme/WebOOT/env/lib/python2.6/site-packages/pyramid/config/views.py', line 333 in rendered_view
  result = view(context, request)
File '/home/sschmitt/programme/WebOOT/weboot/views/**init**.py', line 21 in view_root_object
  return dict(path=build_breadcrumbs(context),
File '/home/sschmitt/programme/WebOOT/weboot/views/breadcrumb.py', line 51 in build_breadcrumbs
  args = this_context, build_submenu(this_context.**parent**, this_context.**name**, fragments[1:])
File '/home/sschmitt/programme/WebOOT/weboot/views/breadcrumb.py', line 37 in build_submenu
  good_keys = [k for k in c.keys() if k != name and basic_traverse(c[k], fragments)]
File '/home/sschmitt/programme/WebOOT/weboot/views/breadcrumb.py', line 12 in basic_traverse
  context = context[name]
File '/home/sschmitt/programme/WebOOT/weboot/resources/baskets.py', line 55 in **getitem**
  basket = self.request.db.baskets.find({"basket" : path})
AttributeError: 'NoneType' object has no attribute 'baskets'

Thanks,

Sebastian
