### PR TITLE
Actions refactor

### DIFF
--- a/weboot/resources/actions.py
+++ b/weboot/resources/actions.py
@@ -132,10 +132,16 @@ class HasActions(object):
     @action
     def p(self, parent, key, param, value):
         """
-        Collect a parameter
+        Store a parameter
+        
+        (BUG)
+        Note: This does not cause the action to enter the traversal hierarchy
+        because `from_parent` isn't used. What is needed is a way to create
+        a copy of `self` which can be placed correctly into the hierarchy.
+        (pwaller) doesn't currently know how to achieve this reliably.
         """
-        self.request.params[param] = value
-        return self.from_parent(parent, key)
+        self.request.params.multi.dicts += ({param:value},)
+        return self
     
     @action
     def lineage(self, key):

--- a/weboot/resources/actions.py
+++ b/weboot/resources/actions.py
@@ -168,10 +168,12 @@ class HasActions(object):
         ret = self.try_action(key)
         if ret: return ret
 
+# Needs to go here to avoid circular imports
 # LocationAware inherits from HasActions.
 from weboot.resources.locationaware import LocationAware
-            
-class ArgumentCollector(LocationAware):
+from .renderable import Renderer
+
+class ArgumentCollector(Renderer):
     """
     An intermediate class which collects arguments and passes them all in one 
     go to the desired function
@@ -180,6 +182,12 @@ class ArgumentCollector(LocationAware):
         self.request = request
         self.function, self.parameters, self.resource = function, parameters, resource
         self.args = args
+    
+    @property
+    def content(self):
+        msg = ("Expected more arguments for action '{0}', got {1}, expected {2}"
+                .format(self.target, self.args, self.parameters))
+        return Response(msg, content_type="text/html")
     
     @property
     def target(self):
@@ -198,9 +206,6 @@ class ArgumentCollector(LocationAware):
         # Collect this argument
         return ArgumentCollector.from_parent(self, key, self.function,
             self.parameters, self.resource, args)
-
-# Needs to go here to avoid circular imports
-from .renderable import Renderer
 
 class ResponseContext(Renderer):
     def __init__(self, request, body, **kwargs):

--- a/weboot/resources/baskets.py
+++ b/weboot/resources/baskets.py
@@ -94,8 +94,6 @@ class BasketTraverser(LocationAware):
         return MultipleTraverser.from_parent(self, key, indexed_contexts, slot_filler=i_dont_know)
     
     def __getitem__(self, key):
-        res = self.try_action(key)
-        if res: return res
     
         if not isinstance(key, int) and not key.isdigit():
             return

--- a/weboot/resources/combination.py
+++ b/weboot/resources/combination.py
@@ -588,8 +588,6 @@ class Combination(Renderable, LocationAware):
         return iter(self.keys())
     
     def __getitem__(self, key):
-        res = self.try_action(key)
-        if res: return res
         
         if not isinstance(key, basestring):
             key = str(key)

--- a/weboot/resources/multitraverser.py
+++ b/weboot/resources/multitraverser.py
@@ -419,9 +419,7 @@ class MultipleTraverser(LocationAware):
         return []
     
     def __getitem__(self, key):
-        res = self.try_action(key)
-        if res: return res
-        
+            
         # Traverse inside each of the contained contexts
         new_contexts = []
         for index_tuple, context in self.indexed_contexts:

--- a/weboot/resources/renderable.py
+++ b/weboot/resources/renderable.py
@@ -163,14 +163,7 @@ class RootRenderer(Renderer):
         if self.format == "raise":
             class UserThrow(RuntimeError): pass
             raise UserThrow("Stopping because you asked me to.")
-            
-        if self.format == "parentage":
-            contents = []
-            from pyramid.location import lineage
-            for element in lineage(self):
-                contents.append(str(element))
-            return Response("\n".join(contents), content_type="text/plain")
-    
+                
         print "Rendering..", self.format, self
         params = self.params
         params.update(self.request.params)

--- a/weboot/resources/renderable.py
+++ b/weboot/resources/renderable.py
@@ -70,7 +70,7 @@ class Renderable(HasActions):
         return self.rendered("png")["!resolution"][icon_resolution]
         
     def rendered(self, format):
-        if not context_renderable_as(self, "png"):
+        if not context_renderable_as(self, format):
             raise RuntimeError("Error rendering {0}: "
                                   "not renderable as {1}".format(self, format))
         return self["!render"][format]

--- a/weboot/resources/root/histogram.py
+++ b/weboot/resources/root/histogram.py
@@ -314,6 +314,14 @@ class Histogram(Renderable, RootObject):
         return ['<p><img class="plot" src="{0}" /></p>'.format(rendered.sub_url(query={"todo-removeme": 1}))]
         #self.sub_url(query={"render":None, "resolution":70}))]
         
+    @action
+    def freqhist(self, parent, key):
+        return FreqHist.from_parent(parent, key, self.o)
+        
+    @action
+    def table(self, parent, key):
+        return HistogramTable.from_parent(parent, key, self.o)
+        
 class FreqHist(Histogram):
     def __init__(self, request, root_object):
         from cPickle import loads

--- a/weboot/resources/root/histogram.py
+++ b/weboot/resources/root/histogram.py
@@ -288,8 +288,12 @@ class Histogram(Renderable, RootObject):
             return
             
         def tf(h):
-
-            h = normalize_by_axis(self.obj, axes == "x")
+            h = normalize_by_axis(h, axes == "x")
+            #h = h.Clone("Test")
+            # BUG TODO(pwaller): Not leak memory
+            #                    For some reason this is necessary at the moment
+            #                    (It results in a blank canvas being drawn otherwise)
+            R.SetOwnership(h, False)
             return h
 
         return Histogram.from_parent(parent, key, self.o.transform(tf))

--- a/weboot/resources/root/object.py
+++ b/weboot/resources/root/object.py
@@ -62,28 +62,13 @@ class RootObject(LocationAware, ListingItem):
     def icon_url(self):
         return static_url('weboot:static/close_32.png', self.request)
     
-    def __getitem__(self, key):
-        
-        # TODO(pwaller): fix this mess
-        from .histogram import FreqHist, HistogramTable
-        from .ttree import DrawTTree
-            
-        if key == "!table":
-            return HistogramTable.from_parent(self, "!table", self.o)
-
-        elif key == "!basket":
-            if not self.request.db:
-                raise HTTPMethodNotAllowed("baskets not available - no connect to database")
-            else:
-                self.request.db.baskets.insert({"basket":"my_basket", "path": resource_path(self), "name": self.name})
-                print "adding %s to basket" % self.url
-                return HTTPFound(location=self.url)
-
-        elif key == "!freqhist":
-            return FreqHist.from_parent(self, "!freqhist", self.o)
-            
-        elif key == "!tohist":
-            return DrawTTree.from_parent(self, "!tohist", self.o)
-
-
+    @action
+    def basket(self, parent, key):
+        if not self.request.db:
+            raise HTTPMethodNotAllowed("baskets not available - no connect to database")
+        else:
+            self.request.db.baskets.insert({"basket":"my_basket",
+                "path": resource_path(self), "name": self.name})
+            log.debug("adding {0} to basket".format(self.url))
+            return HTTPFound(location=self.url)
 

--- a/weboot/resources/root/object.py
+++ b/weboot/resources/root/object.py
@@ -63,8 +63,6 @@ class RootObject(LocationAware, ListingItem):
         return static_url('weboot:static/close_32.png', self.request)
     
     def __getitem__(self, key):
-        res = self.try_action(key)
-        if res: return res
         
         # TODO(pwaller): fix this mess
         from .histogram import FreqHist, HistogramTable

--- a/weboot/resources/root/tree.py
+++ b/weboot/resources/root/tree.py
@@ -37,13 +37,14 @@ class Tree(RootObject):
         def draw(t):
         
             if self.binning:
-                # TODO: gDirectory needs to be thread-unique. Otherwise:
+                # TODO(pwaller): gDirectory needs to be thread-unique. Otherwise:
                 #       bad bad, sad sad.
-                # TODO: Parse self.binning, call appropriate h.
+                # TODO(pwaller): Parse self.binning, call appropriate h.
                 n, low, hi = self.binning.split(",")
                 n, low, hi = int(n), float(low), float(hi)
                 h = R.TH1D("htemp", arg, n, low, hi)
                 h.SetDirectory(R.gDirectory)
+                # BUG: TODO(pwaller): Memory leak
                 R.SetOwnership(h, False)
         
             drawn = t.Draw(arg + ">>htemp", self.selection, "goff")


### PR DESCRIPTION
This set of commits simplifies what is going on with actions quite a bit, and makes them a little less error prone in that it is now not possible to accidentally leave out the `try_action`.

This is at the expense of making them a bit more magical, by making `HasActionsMeta` wrap the `__getitem__` of any subclasses with something which first runs `try_action`.

A few comments have been added, and `!lineage` is now supported everywhere.
