### PR TITLE
installation problem, missing README.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os.path import abspath, dirname, exists, join as pjoin
 from setuptools import setup, find_packages
 
 here = abspath(dirname(__file__))
-README = open(pjoin(here, 'README.txt')).read()
+README = open(pjoin(here, 'README.md')).read()
 CHANGES = open(pjoin(here, 'CHANGES.txt')).read()
 
 requires = [


### PR DESCRIPTION
Hello, I tried to install WebOOT, it seems that the README.txt is mandatory:

```
turra@localhost:~/WebOOT> python setup.py 
Traceback (most recent call last):
  File "setup.py", line 10, in <module>
    README = open(pjoin(here, 'README.txt')).read()
IOError: [Errno 2] No such file or directory: '/home/turra/WebOOT/README.txt'
```

I created an empty file and it works.

Linux localhost.localdomain 3.7.9-104.fc17.x86_64 #1 SMP Sun Feb 24 19:19:12 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
Python 2.7.3 (default, Jul 24 2012, 10:05:38) 
[GCC 4.7.0 20120507 (Red Hat 4.7.0-5)] on linux2
