### PR TITLE
handle ROOTError (illegal number of points) when saving canvas (issue #77)

### DIFF
--- a/weboot/resources/renderable.py
+++ b/weboot/resources/renderable.py
@@ -12,6 +12,8 @@ from pyramid.response import Response
 
 import ROOT as R
 
+from rootpy import ROOTError
+
 from weboot import log; log = log.getChild("renderable")
 
 from .actions import HasActions, action
@@ -185,7 +187,14 @@ class RootRenderer(Renderer):
                     raise NotImplementedError()
                 
                 canvas.Update()
-                canvas.SaveAs(tmpfile.name)
+                try:
+                    canvas.SaveAs(tmpfile.name)
+                except ROOTError as err:
+                    if "illegal number of points" in err.msg:
+                        log.warning('problem plotting canvas "%s", error from ROOT %s', canvas.GetName(), err.msg)
+                    else:
+                        raise err
+
                 
             # TODO(pwaller): figure out why these two lines are preventing
             #                 blank images. (wtf?)

--- a/weboot/resources/renderable.py
+++ b/weboot/resources/renderable.py
@@ -191,9 +191,9 @@ class RootRenderer(Renderer):
                     canvas.SaveAs(tmpfile.name)
                 except ROOTError as err:
                     if "illegal number of points" in err.msg:
-                        log.warning('problem plotting canvas "%s", error from ROOT %s', canvas.GetName(), err.msg)
+                        log.warning('problem plotting canvas "%s", error from ROOT "%s"', canvas.GetName(), err.msg)
                     else:
-                        raise err
+                        raise
 
                 
             # TODO(pwaller): figure out why these two lines are preventing


### PR DESCRIPTION
I tried to fix issue #77 with this patch. Here I am intercepting ROOTError with message " illegal number of points" when saving a canvas. I don't see a better solution since there is no hierarchy of ROOTError exceptions, apart from intercepting all the ROOTErros.

The bearmer presentation works now.

In addition now canvases with no points are also displayed.

![download](https://f.cloud.github.com/assets/143389/273412/a327faf8-9022-11e2-855f-7dae66898c46.png)
