### PR TITLE
problem with installation following README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ Using virtualenv you can install all dependencies
 in the current directory:
 
     git clone git://github.com/rootpy/WebOOT
-    python WebOOT/setup.py develop --user
+    cd WebOOT/
+    python setup.py develop --user
     mkdir results/
     # Copy some histograms to your results/ directory, then run..
-    pserve --reload WebOOT/development.ini
+    ${HOME}/.local/bin/pserve --reload development.ini
 
 Please see `CONTRIBUTING`.
 


### PR DESCRIPTION
git clone git://github.com/rootpy/WebOOT --works
python WebOOT/setup.py develop --user -- works after "sudo easy_install -U distribute"
mkdir results/ -- should be "WebOOT/results"?
pserve --reload WebOOT/development.ini -- fails

pserve cannot be found, it got installed in ~/.local/bin, so 
   export PATH=$PATH:~/.local/bin
helped.

Next problem:

...
  File "/usr/local/lib/python2.7/dist-packages/distribute-0.6.35-py2.7.egg/pkg_resources.py", line 2015, in load
    entry = **import**(self.module_name, globals(),globals(), ['**name**'])
ImportError: No module named weboot

To solve it, I did:

export PYTHONPATH=$PYTHONPATH:`readlink -f WebOOT`

$ pserve --reload WebOOT/development.ini  
Starting subprocess with file monitor
Starting server in PID 28700.
serving on http://0.0.0.0:6543

yippie.
