### PR TITLE
Browse path and README update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /*.egg-info
 /env
 /results
+/.project
+/.pydevproject

--- a/README.md
+++ b/README.md
@@ -8,29 +8,61 @@ Fed up with writing plot scripts?
 # Introduction
 
 WebOOT aims to make it easy to make navigate between ROOT files and do advanced
-maniuplation on many plots simultaneously.
+manipulation on many plots simultaneously.
 
 The first idea is that all plots should be addressable at a URL.
 
 # Prerequisites
 
-If these work, then weboot should work:
+To make WebOOT work, you need
+[PyROOT](http://root.cern.ch/drupal/content/pyroot),
+[ImageMagick](http://www.imagemagick.org/),
+[pexpect](https://pypi.python.org/pypi/pexpect/) and
+[filemagic](https://pypi.python.org/pypi/filemagic/).
+
+Copy & paste these commands into a shell to check:
 
     $ python -c "import ROOT"
     $ convert -h
-    (from ImageMagick)
+    $ python -c "import pexpect"
+    $ python -c "import magic"
 
 # Installation
 
-Using virtualenv you can install all dependencies
-in the current directory:
+This is a simple way to install WebOOT:
 
     git clone git://github.com/rootpy/WebOOT
     cd WebOOT/
     python setup.py develop --user
-    mkdir results/
-    # Copy some histograms to your results/ directory, then run..
-    ${HOME}/.local/bin/pserve --reload development.ini
+
+Extra Python package dependencies that WebOOT uses and you don't have already
+will be fetched and installed automatically
+from [PyPI](https://pypi.python.org/pypi/):
+[rootpy](https://pypi.python.org/pypi/rootpy/)
+[pyramid](https://pypi.python.org/pypi/pyramid/),
+[pyramid_debugtoolbar](https://pypi.python.org/pypi/pyramid_debugtoolbar/),
+[waitress](https://pypi.python.org/pypi/waitress/),
+[Paste](https://pypi.python.org/pypi/Paste/),
+[PasteScript](https://pypi.python.org/pypi/PasteScript/),
+[PasteDeploy](https://pypi.python.org/pypi/PasteDeploy/),
+[WebError](https://pypi.python.org/pypi/WebError/)
+
+# Usage
+
+If you downloaded WebOOT to `Folder_A` and want to browse your ROOT files in `Folder_B`,
+open a terminal and type
+
+    $ cd Folder_A
+    $ pserve --reload Folder_B/development.ini
+
+You will get a message on your screen that looks like this:
+
+	Starting subprocess with file monitor
+	Starting server in PID 31840.
+	serving on http://0.0.0.0:6543
+
+Copy & paste the URL into the web browser of your choice and follow the `browse` link
+( or go directly to http://0.0.0.0:6543/browse/ ).
 
 Please see `CONTRIBUTING`.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Copy & paste these commands into a shell to check:
 
     $ python -c "import ROOT"
     $ convert -h
-    $ python -c "import pexpect"
     $ python -c "import magic"
 
 # Installation
@@ -36,8 +35,7 @@ This is a simple way to install WebOOT:
     python setup.py develop --user
 
 Extra Python package dependencies that WebOOT uses and you don't have already
-will be fetched and installed automatically
-from [PyPI](https://pypi.python.org/pypi/):
+will be fetched and installed from [PyPI](https://pypi.python.org/pypi/) automatically:
 [rootpy](https://pypi.python.org/pypi/rootpy/)
 [pyramid](https://pypi.python.org/pypi/pyramid/),
 [pyramid_debugtoolbar](https://pypi.python.org/pypi/pyramid_debugtoolbar/),
@@ -45,7 +43,7 @@ from [PyPI](https://pypi.python.org/pypi/):
 [Paste](https://pypi.python.org/pypi/Paste/),
 [PasteScript](https://pypi.python.org/pypi/PasteScript/),
 [PasteDeploy](https://pypi.python.org/pypi/PasteDeploy/),
-[WebError](https://pypi.python.org/pypi/WebError/)
+[WebError](https://pypi.python.org/pypi/WebError/).
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ A web ROOT viewer.
 
 Fed up with writing plot scripts?
 
-# Introduction
+## Introduction
 
 WebOOT aims to make it easy to make navigate between ROOT files and do advanced
 manipulation on many plots simultaneously.
 
 The first idea is that all plots should be addressable at a URL.
 
-# Prerequisites
+## Prerequisites
 
 To make WebOOT work, you need
 [PyROOT](http://root.cern.ch/drupal/content/pyroot),
@@ -26,7 +26,7 @@ Copy & paste these commands into a shell to check:
     $ convert -h
     $ python -c "import magic"
 
-# Installation
+## Installation
 
 This is a simple way to install WebOOT:
 
@@ -34,18 +34,8 @@ This is a simple way to install WebOOT:
     cd WebOOT/
     python setup.py develop --user
 
-Extra Python package dependencies that WebOOT uses and you don't have already
-will be fetched and installed from [PyPI](https://pypi.python.org/pypi/) automatically:
-[rootpy](https://pypi.python.org/pypi/rootpy/)
-[pyramid](https://pypi.python.org/pypi/pyramid/),
-[pyramid_debugtoolbar](https://pypi.python.org/pypi/pyramid_debugtoolbar/),
-[waitress](https://pypi.python.org/pypi/waitress/),
-[Paste](https://pypi.python.org/pypi/Paste/),
-[PasteScript](https://pypi.python.org/pypi/PasteScript/),
-[PasteDeploy](https://pypi.python.org/pypi/PasteDeploy/),
-[WebError](https://pypi.python.org/pypi/WebError/).
 
-# Usage
+## Usage
 
 If you downloaded WebOOT to `Folder_A` and want to browse your ROOT files in `Folder_B`,
 open a terminal and type

--- a/development.ini
+++ b/development.ini
@@ -14,7 +14,8 @@ pyramid.includes =
 # 	    
 debugtoolbar.hosts = 0.0.0.0/0
 
-results_path = %(here)s/results
+# Start browsing in the current working directory
+results_path = .
 
 #mongo.url = mongodb://localhost/
 #mongo.dbpath = %(here)s/data

--- a/weboot/templates/home.pt
+++ b/weboot/templates/home.pt
@@ -61,6 +61,8 @@
 
     <h2>Starting points</h2>
     <ul>
+        <li><a href="${request.url}browse/">${request.url}browse/</a> :
+        Browse your ROOT files</li>
         <li><a href="${request.url}me/">${request.url}me/</a> :
         Go and look at some of your plots on AFS</li>
         <li><a href="${request.url}dashboard/">${request.url}dashboard/</a> :

--- a/weboot/templates/home.pt
+++ b/weboot/templates/home.pt
@@ -9,7 +9,7 @@
     
     <script type="text/javascript">
         $(function () {
-            $.getJSON("https://github.com/api/v2/json/issues/list/pwaller/WebOOT/open?callback=?", 
+            $.getJSON("https://github.com/api/v2/json/issues/list/rootpy/WebOOT/open?callback=?", 
                 function (result) {
                     $("#number_of_issues").text(result["issues"].length);
                 });
@@ -42,7 +42,7 @@
             of a mess.</li>
     </ul>
     <p>Please report broken things, ideas or complaints at 
-       <a href="https://github.com/pwaller/WebOOT/issues">WebOOT issues</a> on github.
+       <a href="https://github.com/rootpy/WebOOT/issues">WebOOT issues</a> on github.
        There are currently <span id="number_of_issues">lots</span> open but between us we'll get around to it. 
        If you record an idea, it can't be permanently forgotten.
     </p>
@@ -51,20 +51,22 @@
     <h2>A community project</h2>
     <p>You are currently looking at one instance of the WebOOT server, running on <span class="host">${host}</span>. 
         You can start your own instance on <span class="host">${remote_host}</span> or wherever you like in a matter of 
-        <a href="https://github.com/pwaller/WebOOT/blob/master/README.txt">minutes</a>.
-        Anyone can get the source from <a href="https://github.com/pwaller/WebOOT/">github</a> 
+        <a href="https://github.com/rootpy/WebOOT/blob/master/README.md">minutes</a>.
+        Anyone can get the source from <a href="https://github.com/rootpy/WebOOT/">github</a> 
         and start committing to it without permission from anybody.
-        If you <a href="https://github.com/pwaller/WebOOT/blob/master/CONTRIBUTING">make something</a> cool, let us know by sending a 
+        If you <a href="https://github.com/rootpy/WebOOT/blob/master/CONTRIBUTING">make something</a> cool, let us know by sending a 
         <a href="http://help.github.com/send-pull-requests/">pull request</a>. 
         That will make the most of both of our time.</p>
     <br />
 
     <h2>Starting points</h2>
     <ul>
-        <li><a href="${request.url}me/">${request.url}me/</a> : Go and look at 
-        some of your plots on AFS</li>
-        <li><a href="${request.url}dashboard/">${request.url}dashboard/</a> : Find some plots that are being shared with you.</li>
-        <li><a href="${request.url}~${login}/">${request.url}~${login}/</a> : Share plots with others.</li>
+        <li><a href="${request.url}me/">${request.url}me/</a> :
+        Go and look at some of your plots on AFS</li>
+        <li><a href="${request.url}dashboard/">${request.url}dashboard/</a> :
+        Find some plots that are being shared with you.</li>
+        <li><a href="${request.url}~${login}/">${request.url}~${login}/</a> :
+        Share plots with others.</li>
     </ul>
 
 </tal:block>


### PR DESCRIPTION
I think it is easier to explain / remember to simply go to the folder where you want to browser the ROOT files instead of having to always create a subfolder called `result`.
