### PR TITLE
Python interpreter hangs on exit after importing weboot

### DIFF
--- a/weboot/utils/root_vfs.py
+++ b/weboot/utils/root_vfs.py
@@ -555,4 +555,5 @@ def maintenance_main():
         RootCacheFile.maintenance()
 maintenance_thread = Thread()
 maintenance_thread.run = maintenance_main
+maintenance_thread.setDaemon(True)
 maintenance_thread.start()


### PR DESCRIPTION
The Python interpreter (I tried two Macs, I didn't try Linux yet) hangs on exit if `weboot` was imported:

```
$ python -c 'import weboot; print "hi"'
hi
^C^C^C^\Quit: 3
```

Can someone reproduce?
Any idea how to debug this?
